### PR TITLE
Simplify Snackbar component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -627,26 +627,24 @@ export class Slider extends MaterialComponent {
 }
 
 
+
+
 /** Snackbar
  */
 
 export class Snackbar extends MaterialComponent {
 	component = 'snackbar';
-}
+	js = true;
 
-export class SnackbarText extends MaterialComponent {
-	component = 'snackbar__text';
+	mdlRender(props) {
+		return (
+			<div {...props}>
+				<div class="mdl-snackbar__text"></div>
+				<button class="mdl-snackbar__action" type="button"></button>
+			</div>
+		);
+	}
 }
-
-export class SnackbarAction extends MaterialComponent {
-	component = 'snackbar__action';
-	nodeName = 'button';
-}
-
-extend(Snackbar, {
-	Text: SnackbarText,
-	Action: SnackbarAction
-});
 
 
 


### PR DESCRIPTION
I realized it makes no sense to expose `Snackbar.Text` and `Snackbar.Action`, as MDL always expects them to be there, and they can't have user-specified children. Users should always do:

``` js
snackbarContainer.MaterialSnackbar.showSnackbar({
      message: 'Your message has been deleted.',
      timeout: 2000,
      actionHandler: handler,
      actionText: 'Undo'
});
```

Sorry. 😓
