### PR TITLE
Fixing problem with Switches disappearing after toggle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -766,6 +766,10 @@ export class Switch extends MaterialComponent {
 			<label {...props}>
 				<input type="checkbox" class="mdl-switch__input" checked={ props.checked } disabled={ props.disabled } {...evt} />
 				<span class="mdl-switch__label">{ props.children }</span>
+				<div class="mdl-switch__track"></div>
+				<div class="mdl-switch__thumb">
+					<span class="mdl-switch__focus-helper"></span>
+				</div>
 			</label>
 		);
 	}


### PR DESCRIPTION
Because MDL injects new HTML elements into the DOM which the Virtual DOM does not notice the Switch component is broken after being toggled one time.
This addresses this by adding the elements that MDL otherwise would inject, and the toggle now works multiple times.
