### PR TITLE
Add some missing properties in typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,10 @@ export interface ButtonProps extends HTMLProps {
 export class Button extends MaterialComponent<ButtonProps, {}> { }
 
 /** Cards */
-export class Card extends MaterialComponent<HTMLProps, {}> { }
+export interface CardProps extends HTMLProps {
+    shadow?: number;
+}
+export class Card extends MaterialComponent<CardProps, {}> { }
 export class CardActions extends MaterialComponent<HTMLProps, {}> { }
 export class CardMedia extends MaterialComponent<HTMLProps, {}> { }
 export class CardMenu extends MaterialComponent<HTMLProps, {}> { }
@@ -243,6 +246,7 @@ export interface TextFieldProps extends HTMLProps {
     errorMessage?: string;
     expandable?: boolean;
     multiline?: boolean;
+    onSearch?: ((event) => boolean|void);
 }
 export class TextField extends MaterialComponent<TextFieldProps, {}> { }
 


### PR DESCRIPTION
These are used in [this JSFiddle](https://jsfiddle.net/developit/weq28uq3/) so they had to be added to the typings. Note that there may be quite a few more properties missing, but I'm not sure where the complete list of possible properties would be listed. Are you aware of such a list? If so, I'll amend this PR with the full list of properties.