### PR TITLE
Fix TextField not having is-invalid class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -826,6 +826,7 @@ List.Item = ListItem;
 /** @prop floating-label = false
 *	@prop multiline = false
 *	@prop expandable = false
+*	@prop errorMessage = null
 *	@prop icon (used with expandable)
  */
 export class TextField extends MaterialComponent {
@@ -877,6 +878,10 @@ export class TextField extends MaterialComponent {
 		let cl = getClass(props);
 		if (cl) {
 			(field.attributes = field.attributes || {}).class = cl;
+		}
+
+		if (errorMessage) {
+			setClass((field.attributes = field.attributes || {}), 'is-invalid', true);
 		}
 		return field;
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import { h, render, Component } from 'preact';
 import assertJsx from 'preact-jsx-chai';
 chai.use(assertJsx);
-import { Button } from '..';
+import { Button, TextField } from '..';
 
 /*eslint-env browser,mocha*/
 /*global sinon,expect,chai*/
@@ -32,6 +32,26 @@ describe('preact-mdl', () => {
 					Text
 				</button>
 			);
+		});
+	});
+
+	describe('<TextField />', () => {
+		it('should add the custom class', () => {
+			let field = <TextField class="custom_class"/>;
+			expect(field).to.contain('custom_class');
+		});
+
+		it('should display an errorMessage if exists', () => {
+			let field = <TextField errorMessage="error message" />;
+			expect(field).to.contain('error message');
+			expect(field).to.contain('is-invalid');
+		});
+
+		it('should display an errorMessage with custom class', () => {
+			let field = <TextField errorMessage="error message" class="custom_class"/>;
+			expect(field).to.contain('error message');
+			expect(field).to.contain('is-invalid');
+			expect(field).to.contain('custom_class');
 		});
 	});
 });


### PR DESCRIPTION
When errorMessage was set, is-invalid should be added to the container
div. This commit fixes this, and also adds several tests to make sure it
does not interfere with existing options.

fixes #29 