### PR TITLE
Not deleting attributes.className.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ function extend(base, props) {
 
 function setClass(attributes, value, append) {
 	let cl = getClass(attributes);
-	if (attributes.className) delete attributes.className;
 	if (append) value = cl ? (cl + ' ' + value) : value;
 	attributes.class = value;
 }


### PR DESCRIPTION
Hi. I came across an issue that, if I use className, when the preact components re-renders, the class attributes in my elements are lost. If I use "class", everything just works. I realize that preact recommends class over className, but since className was supposed to work as well (at least according to https://github.com/developit/preact/issues/103), I'd consider this a bug.

This is a simple change, but I imagine this code is here for a reason.

Thanks in advance!